### PR TITLE
expire throttle keys in redis

### DIFF
--- a/spec/defense_ban_spec.rb
+++ b/spec/defense_ban_spec.rb
@@ -8,7 +8,7 @@ describe 'Rack::Defense::ban' do
     Rack::Defense.setup do |config|
       # allow only given ips on path
       config.ban('allow_only_ip_list') do |req|
-        req.path == '/protected' && !['192.168.0.1', '127.0.0.1'].include?(req.ip)
+        req.path == '/protected' && !%w(192.168.0.1 127.0.0.1).include?(req.ip)
       end
     end
   end
@@ -27,7 +27,7 @@ describe 'Rack::Defense::ban' do
 
   def check_request(verb, path, ip)
     send verb, path, {}, 'REMOTE_ADDR' => ip
-    expected_status = path == '/protected' && !['192.168.0.1', '127.0.0.1'].include?(ip) ?
+    expected_status = path == '/protected' && !%w(192.168.0.1 127.0.0.1).include?(ip) ?
       status_banned : status_ok
     assert_equal expected_status, last_response.status
   end

--- a/spec/defense_throttle_expire_keys_spec.rb
+++ b/spec/defense_throttle_expire_keys_spec.rb
@@ -1,0 +1,38 @@
+require_relative 'spec_helper'
+
+describe 'Rack::Defense::throttle_expire_keys' do
+  def window
+    10 * 1000 # in milliseconds
+  end
+
+  before do
+    Rack::Defense.setup do |config|
+      # allow 1 requests per #window per ip
+      config.throttle('rule', 3, window) { |req| req.ip if req.path == '/path' }
+    end
+  end
+
+  it 'expire throttle key' do
+    ip = '192.168.169.244'
+    throttle_key = "#{Rack::Defense::ThrottleCounter::KEY_PREFIX}:rule:#{ip}"
+    redis = Rack::Defense.config.store
+    start = Time.now.to_i
+    3.times do
+      get '/path', {}, 'REMOTE_ADDR' => ip
+      assert status_ok, last_response.status
+    end
+
+    get '/path', {}, 'REMOTE_ADDR' => ip
+    elapsed = Time.now.to_i - start
+    if elapsed < window
+      assert status_throttled, last_response.status
+      assert redis.exists throttle_key
+    else
+      puts "test too slow elapsed:#{elapsed}s expected < #{window}"
+    end
+
+    sleep window/1000
+
+    refute redis.exists throttle_key
+  end
+end

--- a/spec/throttle_counter_spec.rb
+++ b/spec/throttle_counter_spec.rb
@@ -2,11 +2,10 @@ require_relative 'spec_helper'
 
 describe Rack::Defense::ThrottleCounter do
   before do
-    @counter = Rack::Defense::ThrottleCounter.new('upload_photo', 5, 10, Redis.current)
     @key = '192.168.0.1'
   end
-
   describe '.throttle?' do
+    before { @counter = Rack::Defense::ThrottleCounter.new('upload_photo', 5, 10, Redis.current) }
     it 'allow request number max_requests if after period' do
       do_max_requests_minus_one
       refute @counter.throttle? @key, 11
@@ -37,6 +36,35 @@ describe Rack::Defense::ThrottleCounter do
       assert @counter.throttle? @key, 10
       [16, 17, 18, 19].each { |t| refute @counter.throttle?(@key, t), "timestamp #{t}" }
       assert @counter.throttle? @key, 20
+    end
+  end
+  describe 'expire keys' do
+    before do
+      @redis = Redis.current
+      @counter = Rack::Defense::ThrottleCounter.new('rule_name', 3, 10 * 1000, @redis)
+      @throttle_key = "#{Rack::Defense::ThrottleCounter::KEY_PREFIX}:rule_name:#{@key}"
+    end
+    it 'expire throttle key' do
+      start = Time.now.to_i
+
+      3.times do
+        refute @counter.throttle? @key
+      end
+
+      elapsed = Time.now.to_i - start
+      if elapsed < 10
+        assert @counter.throttle? @key
+        assert @redis.exists @throttle_key
+      else
+        puts "Warning: test too slow elapsed:#{elapsed}s expected < #{10}"
+      end
+
+      # see http://redis.io/commands/expire
+      # In Redis 2.4 the expire might not be pin-point accurate, and it could be between zero to one seconds out.
+      # Since Redis 2.6 the expire error is from 0 to 1 milliseconds.
+      sleep 10 + 0.001
+
+      refute @redis.exists @throttle_key
     end
   end
 


### PR DESCRIPTION
Expire throttle keys in redis so that they are automatically removed if no activity is recorded for a given key.
