### PR TITLE
Tests to not fail when run slowly due to expiring redis keys

### DIFF
--- a/lib/rack/defense/throttle_counter.rb
+++ b/lib/rack/defense/throttle_counter.rb
@@ -27,7 +27,7 @@ module Rack
                        (timestamp - time_period) <= tonumber(redis.call('lpop', key))
       redis.call('pexpire', key, time_period)
       return throttle
-LUA_SCRIPT
+      LUA_SCRIPT
 
       private_constant :SCRIPT
     end

--- a/spec/defense_callbacks_spec.rb
+++ b/spec/defense_callbacks_spec.rb
@@ -50,7 +50,6 @@ describe 'Rack::Defense::callbacks' do
   end
 
   def check_callback_data(trace, matching_request_count, rule_data, req_path)
-    puts
     assert_equal matching_request_count, trace.length
     data = trace[-1]
     # check callback data

--- a/spec/defense_throttle_expire_keys_spec.rb
+++ b/spec/defense_throttle_expire_keys_spec.rb
@@ -28,10 +28,11 @@ describe 'Rack::Defense::throttle_expire_keys' do
       assert status_throttled, last_response.status
       assert redis.exists throttle_key
     else
-      puts "test too slow elapsed:#{elapsed}s expected < #{window}"
+      puts "Warning: test too slow elapsed:#{elapsed}s expected < #{window}"
     end
 
-    sleep window/1000
+    # Since Redis 2.6 the expire error is from 0 to 1 milliseconds. See http://redis.io/commands/expire
+    sleep (window / 1000) + 0.002
 
     refute redis.exists throttle_key
   end

--- a/spec/throttle_counter_spec.rb
+++ b/spec/throttle_counter_spec.rb
@@ -5,37 +5,38 @@ describe Rack::Defense::ThrottleCounter do
     @key = '192.168.0.1'
   end
   describe '.throttle?' do
-    before { @counter = Rack::Defense::ThrottleCounter.new('upload_photo', 5, 10, Redis.current) }
+    window = 60 * 1000
+    before { @counter = Rack::Defense::ThrottleCounter.new('upload_photo', 5, window, Redis.current) }
     it 'allow request number max_requests if after period' do
       do_max_requests_minus_one
-      refute @counter.throttle? @key, 11
+      refute @counter.throttle? @key, window + 1
     end
     it 'block request number max_requests if in period' do
       do_max_requests_minus_one
-      assert @counter.throttle? @key, 10
+      assert @counter.throttle? @key, window
     end
     it 'allow consecutive valid periods' do
-      (0..20).each { |i| do_max_requests_minus_one(11 * i) }
+      (0..20).each { |i| do_max_requests_minus_one((window + 1) * i) }
     end
     it 'block consecutive invalid requests' do
       do_max_requests_minus_one
-      (0..20).each { |i| assert @counter.throttle?(@key, 10 + i) }
+      (0..20).each { |i| assert @counter.throttle?(@key, window + i) }
     end
     it 'use a sliding window and not reset count after each full period' do
-      [5, 6, 7, 8, 9].each { |t| refute @counter.throttle?(@key, t), "timestamp #{t}" }
-      [12, 13, 14, 15].each { |t| assert @counter.throttle?(@key, t), "timestamp #{t}"}
+      [5, 4, 3, 2, 1].map { |e| window - e }.each { |t| refute @counter.throttle?(@key, t), "timestamp #{t}" }
+      [1, 2, 3, 4].map { |e| window + e }.each { |t| assert @counter.throttle?(@key, t), "timestamp #{t}"}
     end
     it 'should unblock after blocking requests' do
       do_max_requests_minus_one
-      assert @counter.throttle? @key, 10
-      assert @counter.throttle? @key, 11
-      refute @counter.throttle? @key, 16
+      assert @counter.throttle? @key, window
+      assert @counter.throttle? @key, window + 1
+      refute @counter.throttle? @key, window + 6
     end
     it 'should include throttled(blocked) request into the request count' do
       [0, 1, 2, 3, 4].each { |t| refute @counter.throttle?(@key, t), "timestamp #{t}" }
-      assert @counter.throttle? @key, 10
-      [16, 17, 18, 19].each { |t| refute @counter.throttle?(@key, t), "timestamp #{t}" }
-      assert @counter.throttle? @key, 20
+      assert @counter.throttle? @key, window
+      [16, 17, 18, 19].map { |e| window + e }.each { |t| refute @counter.throttle?(@key, t), "timestamp #{t}" }
+      assert @counter.throttle? @key, window + 20
     end
   end
   describe 'expire keys' do
@@ -59,10 +60,8 @@ describe Rack::Defense::ThrottleCounter do
         puts "Warning: test too slow elapsed:#{elapsed}s expected < #{10}"
       end
 
-      # see http://redis.io/commands/expire
-      # In Redis 2.4 the expire might not be pin-point accurate, and it could be between zero to one seconds out.
-      # Since Redis 2.6 the expire error is from 0 to 1 milliseconds.
-      sleep 10 + 0.001
+      # Since Redis 2.6 the expire error is from 0 to 1 milliseconds. See http://redis.io/commands/expire
+      sleep 10 + 0.002
 
       refute @redis.exists @throttle_key
     end


### PR DESCRIPTION
When redis keys are expiring quickly due to short throttle period some tests fail as they are overriding (mocking) the now timestamp. Change tests to have a bigger throttle window to accommodate slow environment like CI.
